### PR TITLE
Build for F4SE v0.6.15 (game version v1.10.120)

### DIFF
--- a/build.py
+++ b/build.py
@@ -4,11 +4,11 @@ import os, sys
 BUILD_DIR        = 'build'
 PROJECT_DIR      = 'src'
 PLATFORM_TOOLSET = 'v140'
-F4SE_REVISION    = 'tags/v0.6.13'
+F4SE_REVISION    = 'tags/v0.6.15'
 
 # Run build tools
 buildOK = os.system('python tools/build-tools/build_plugin.py "{}" "{}" "{}" "{}"'
     .format(BUILD_DIR, PROJECT_DIR, PLATFORM_TOOLSET, F4SE_REVISION))
-    
+
 # Report result
 sys.exit(buildOK)

--- a/src/Config.h
+++ b/src/Config.h
@@ -4,8 +4,8 @@
 //-----------------------
 // Plugin Information
 //-----------------------
-#define PLUGIN_VERSION              17
-#define PLUGIN_VERSION_STRING       "2.6.7"
+#define PLUGIN_VERSION              18
+#define PLUGIN_VERSION_STRING       "2.6.8"
 #define PLUGIN_NAME_SHORT           "rename_anything"
 #define PLUGIN_NAME_LONG            "Rename Anything"
 #define SUPPORTED_RUNTIME_VERSION   CURRENT_RELEASE_RUNTIME


### PR DESCRIPTION
### What

This builds the plugin for F4SE 0.6.15, which is the current latest version.

### Why

I find it highly annoying that various mod authors have their settings holotapes not correctly prepended with `[Settings]` in the front, so I have a hard time finding all the settings. This is where Rename Anything comes into play. Sadly, it is currently not compatible with the latest FO4 on Steam so I decided to give it a bump 👍 

### Thanks

Thanks for all the hard work you put into this mod, it' s really appreciated bro!